### PR TITLE
Handle discrimator property

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,46 @@ schema = {
 OpenApi2JsonSchema.convert(schema)
 ```
 
+### Discriminator
+
+```yaml
+# Sample YAML file
+schema:
+  discriminator:
+    propertyName: key
+    mapping:
+      value1: 'path-to-file-2.yml'
+      value2: 'path-to-file-2.yml'
+  properties:
+    key:
+      type: string
+      enum:
+        - value1
+        - value2
+```
+
+```json
+"schema": {
+  "properties": {
+    "key": {
+      "type": "string",
+      "enum": ["value1", "value2"]
+    }
+  },
+  "discriminator": {
+    "propertyName": "name",
+    "mapping": {
+      "value1": {
+        "type": "object"
+      },
+      "value2": {
+        "type": "array"
+      }
+    }
+  }
+}
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/attribute_handlers/discriminator.rb
+++ b/lib/attribute_handlers/discriminator.rb
@@ -5,10 +5,9 @@ module OpenApi2JsonSchema
     class Discriminator
       def call(discriminator_schema)
         raise "discriminator schema must be a Hash" unless discriminator_schema.is_a?(Hash)
-        raise "discriminator schema must contain mapping" unless discriminator_schema['mapping']
 
-        mapping = discriminator_schema["mapping"]
-        mapping.map do |key, file_path|
+        mapping = discriminator_schema.fetch("mapping")
+        mapping.each do |key, file_path|
           mapping[key] = OpenApi2JsonSchema::RefSchemaParser.new.call(file_path)
         end
 

--- a/lib/attribute_handlers/discriminator.rb
+++ b/lib/attribute_handlers/discriminator.rb
@@ -1,0 +1,19 @@
+require_relative "../ref_schema_parser"
+
+module OpenApi2JsonSchema
+  module AttributeHandlers
+    class Discriminator
+      def call(discriminator_schema)
+        raise "discriminator schema must be a Hash" unless discriminator_schema.is_a?(Hash)
+        raise "discriminator schema must contain mapping" unless discriminator_schema['mapping']
+
+        mapping = discriminator_schema["mapping"]
+        mapping.map do |key, file_path|
+          mapping[key] = OpenApi2JsonSchema::RefSchemaParser.new.call(file_path)
+        end
+
+        discriminator_schema
+      end
+    end
+  end
+end

--- a/lib/open_api_2_json_schema.rb
+++ b/lib/open_api_2_json_schema.rb
@@ -4,13 +4,14 @@ require 'json'
 require 'yaml'
 require_relative "open_api_2_json_schema/version"
 require_relative 'attribute_handlers/all_of'
+require_relative 'attribute_handlers/discriminator'
 
 module OpenApi2JsonSchema
   module_function
 
-  STRUCTS = ['allOf', 'anyOf', 'oneOf', 'not', 'items', 'additionalProperties', 'schema']
+  STRUCTS = ['allOf', 'anyOf', 'oneOf', 'not', 'items', 'additionalProperties', 'schema', 'discriminator']
   NOT_SUPPORTED = [
-    'nullable', 'discriminator', 'readOnly',
+    'nullable', 'readOnly',
     'writeOnly', 'xml', 'externalDocs',
     'example', 'deprecated'
   ]

--- a/lib/open_api_2_json_schema.rb
+++ b/lib/open_api_2_json_schema.rb
@@ -60,7 +60,11 @@ module OpenApi2JsonSchema
           end
         end
       when Hash
-        json_schema[struct] = convert_schema(data)
+        if struct == 'discriminator'
+          json_schema[struct] = AttributeHandlers::Discriminator.new.call(data)
+        else
+          json_schema[struct] = convert_schema(data)
+        end
       else
         # ignore
       end

--- a/spec/attribute_handlers/discriminator_spec.rb
+++ b/spec/attribute_handlers/discriminator_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe OpenApi2JsonSchema::AttributeHandlers::Discriminator do
+  subject { described_class.new.call(discriminator_schema) }
+
+  context "when schema is valid" do
+    let(:discriminator_schema) do
+      {
+        "propertyName" => "key",
+        "mapping" =>
+          {
+            "value" => "/path-to-file#/schema"
+          }
+
+      }
+    end
+    let(:expected_result) do
+      {
+        "propertyName" => "key",
+        "mapping" => {
+          "value" => {
+            'type' => "object"
+          }
+        }
+      }
+    end
+
+    before do
+      expect(OpenApi2JsonSchema::RefSchemaParser).to receive_message_chain(:new, :call)
+        .with("/path-to-file#/schema")
+        .and_return({ "type" => "object" })
+    end
+
+    it { expect(subject).to eq(expected_result) }
+  end
+end

--- a/spec/attribute_handlers/discriminator_spec.rb
+++ b/spec/attribute_handlers/discriminator_spec.rb
@@ -1,6 +1,22 @@
 RSpec.describe OpenApi2JsonSchema::AttributeHandlers::Discriminator do
   subject { described_class.new.call(discriminator_schema) }
 
+  context 'when there is invalid sub-schema' do
+
+    context 'when schema is not a Hash' do
+      let(:discriminator_schema) { [1] }
+
+      it { expect { subject }.to raise_error('discriminator schema must be a Hash') }
+    end
+
+    context 'when schema is not a Hash' do
+      let(:discriminator_schema) { {} }
+
+      it { expect { subject }.to raise_error('discriminator schema must contain mapping') }
+    end
+
+  end
+
   context "when schema is valid" do
     let(:discriminator_schema) do
       {

--- a/spec/attribute_handlers/discriminator_spec.rb
+++ b/spec/attribute_handlers/discriminator_spec.rb
@@ -8,13 +8,6 @@ RSpec.describe OpenApi2JsonSchema::AttributeHandlers::Discriminator do
 
       it { expect { subject }.to raise_error('discriminator schema must be a Hash') }
     end
-
-    context 'when schema is not a Hash' do
-      let(:discriminator_schema) { {} }
-
-      it { expect { subject }.to raise_error('discriminator schema must contain mapping') }
-    end
-
   end
 
   context "when schema is valid" do

--- a/spec/fixtures/discriminator.yml
+++ b/spec/fixtures/discriminator.yml
@@ -1,0 +1,12 @@
+schema:
+  discriminator:
+    propertyName: key
+    mapping:
+      value1: 'spec/fixtures/mapping-value-one.yml'
+      value2: 'spec/fixtures/mapping-value-two.yml'
+  properties:
+    key:
+      type: string
+      enum:
+        - value1
+        - value2

--- a/spec/fixtures/discriminator_json_schema.json
+++ b/spec/fixtures/discriminator_json_schema.json
@@ -1,0 +1,51 @@
+{
+  "schema": {
+    "discriminator": {
+      "propertyName": "key",
+      "mapping": {
+        "value1": {
+          "schema": {
+            "type": "object",
+            "required": ["data"],
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": ["example_one"],
+                "properties": {
+                  "example_one": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  }
+                }
+              }
+            }
+          }
+        },
+        "value2": {
+          "schema": {
+            "type": "object",
+            "required": ["data"],
+            "properties": {
+              "data": {
+                "type": "object",
+                "required": ["example_two"],
+                "properties": {
+                  "example_two": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "properties": {
+      "key": {
+        "type": "string",
+        "enum": ["value1", "value2"]
+      }
+    }
+  },
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/spec/fixtures/mapping-value-one.yml
+++ b/spec/fixtures/mapping-value-one.yml
@@ -1,0 +1,13 @@
+schema:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: object
+      required:
+        - example_one
+      properties:
+        example_one:
+          type: integer
+          exclusiveMinimum: 0

--- a/spec/fixtures/mapping-value-two.yml
+++ b/spec/fixtures/mapping-value-two.yml
@@ -1,0 +1,12 @@
+schema:
+  type: object
+  required:
+    - data
+  properties:
+    data:
+      type: object
+      required:
+        - example_two
+      properties:
+        example_two:
+          type: string

--- a/spec/open_api_2_json_schema_spec.rb
+++ b/spec/open_api_2_json_schema_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe OpenApi2JsonSchema do
         expect(JSON.parse(subject)).to eq expected_data
       end
     end
+
+    context 'when dealing with schema containing discriminator' do
+      let(:path) { 'spec/fixtures/discriminator.yml' }
+
+      it 'converts data correctly' do
+        expected_data = JSON.parse(File.read('spec/fixtures/discriminator_json_schema.json'))
+        expect(JSON.parse(subject)).to eq expected_data
+      end
+    end
   end
 
   describe '.convert' do


### PR DESCRIPTION
## Use Case
- Ability to validate subschema based on the the selected value
- In the sample yaml file below, we can validate one of the given subschema based on selected value
- Some inspiration from https://redocly.com/docs/resources/discriminator/

```yaml
# Sample schema with discriminator
schema:
  discriminator:
    propertyName: key
    mapping:
      value1: 'path-to-file.yml'
      value2: 'path-to-file-2.yml'
  properties:
    key:
      type: string
      enum:
        - value1
        - value2
```

This would result in this JSON schema
```json
"schema": {
  "properties": {
    "key": {
      "type": "string",
      "enum": ["value1", "value2"]
    }
  },
  "discriminator": {
    "propertyName": "name",
    "mapping": {
      "value1": {
        "type": "object"
      },
      "value2": {
        "type": "array"
      }
    }
  }
}
```